### PR TITLE
[eufy] Changed two notification fields to boolean

### DIFF
--- a/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/BoolIntDeserializer.java
+++ b/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/BoolIntDeserializer.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.eufy.internal;
+
+import java.lang.reflect.Type;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.binding.eufy.internal.dto.objects.BoolInt;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+/**
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+@NonNullByDefault
+public class BoolIntDeserializer implements JsonDeserializer<BoolInt> {
+
+    @Override
+    public @Nullable BoolInt deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        BoolInt b = new BoolInt();
+        if (json.getAsJsonPrimitive().isBoolean()) {
+            b.value = json.getAsBoolean();
+        } else {
+            int intValue = json.getAsInt();
+            b.value = intValue == 1;
+        }
+
+        return b;
+    }
+}

--- a/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/EufyBindingConstants.java
+++ b/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/EufyBindingConstants.java
@@ -66,5 +66,6 @@ public class EufyBindingConstants {
     public static final String CHANNEL_ANTITHEFTPROTECTION = "antitheftProtection";
     public static final String CHANNEL_PERSON_DETECTED = "personDetected";
     public static final String CHANNEL_PERSON_NAME = "personName";
+    public static final String CHANNEL_RINGING = "ringing";
     public static final String CHANNEL_MOTION_DETECTED = "motionDetected";
 }

--- a/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/EventDeserializer.java
+++ b/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/EventDeserializer.java
@@ -20,6 +20,7 @@ import org.openhab.binding.eufy.internal.dto.Event;
 import org.openhab.binding.eufy.internal.dto.MotionDetectedEvent;
 import org.openhab.binding.eufy.internal.dto.PersonDetectedEvent;
 import org.openhab.binding.eufy.internal.dto.PropertyChangedEvent;
+import org.openhab.binding.eufy.internal.dto.RingsEvent;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -39,6 +40,7 @@ class EventDeserializer implements JsonDeserializer<Event> {
     private static final String TYPE_MOTION_DETECTED = "motion detected";
     private static final String TYPE_PERSON_DETECTED = "person detected";
     private static final String TYPE_PROPERTY_CHANGED = "property changed";
+    private static final String TYPE_RINGS = "rings";
 
     @Override
     public @Nullable Event deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
@@ -53,6 +55,8 @@ class EventDeserializer implements JsonDeserializer<Event> {
                 return context.deserialize(jsonObject, PersonDetectedEvent.class);
             } else if (jsonType.getAsString().equals(TYPE_PROPERTY_CHANGED)) {
                 return context.deserialize(jsonObject, PropertyChangedEvent.class);
+            } else if (jsonType.getAsString().equals(TYPE_RINGS)) {
+                return context.deserialize(jsonObject, RingsEvent.class);
             }
         }
         return context.deserialize(jsonObject, PropertyChangedEvent.class);

--- a/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/MessageHelper.java
+++ b/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/MessageHelper.java
@@ -17,6 +17,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.eufy.internal.dto.Event;
 import org.openhab.binding.eufy.internal.dto.Message;
 import org.openhab.binding.eufy.internal.dto.ResultMessage;
+import org.openhab.binding.eufy.internal.dto.objects.BoolInt;
 import org.openhab.binding.eufy.internal.dto.objects.Device;
 import org.openhab.binding.eufy.internal.dto.outgoing.OutgoingMessage;
 
@@ -40,7 +41,8 @@ public class MessageHelper {
         gson = new GsonBuilder().registerTypeAdapter(Message.class, new MessageDeserializer())
                 .registerTypeAdapter(Device.class, new DeviceDeserializer())
                 .registerTypeAdapter(ResultMessage.class, new ResultDeserializer())
-                .registerTypeAdapter(Event.class, new EventDeserializer()).create();
+                .registerTypeAdapter(Event.class, new EventDeserializer())
+                .registerTypeAdapter(BoolInt.class, new BoolIntDeserializer()).create();
     }
 
     public static @Nullable Message parse(String message) {

--- a/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/dto/RingsEvent.java
+++ b/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/dto/RingsEvent.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.eufy.internal.dto;
+
+/**
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+public class RingsEvent extends StateChangedEvent {
+
+}

--- a/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/dto/objects/BoolInt.java
+++ b/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/dto/objects/BoolInt.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.eufy.internal.dto.objects;
+
+/**
+ *
+ * @author Joep Admiraal - Initial contribution
+ */
+public class BoolInt {
+    public boolean value;
+}

--- a/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/dto/objects/Doorbell.java
+++ b/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/dto/objects/Doorbell.java
@@ -16,7 +16,7 @@ import org.openhab.binding.eufy.internal.annotations.EufyChannel;
 
 /**
  * Represents a Eufy doorbell
- * 
+ *
  * @author Iwan Bron - Initial contribution
  */
 public class Doorbell extends Device {
@@ -36,9 +36,9 @@ public class Doorbell extends Device {
     @EufyChannel
     private int chimeHomebaseRingtoneType;
     @EufyChannel
-    private int notificationRing;
+    private boolean notificationRing;
     @EufyChannel
-    private int notificationMotion;
+    private boolean notificationMotion;
 
     public boolean isRinging() {
         return ringing;
@@ -104,19 +104,19 @@ public class Doorbell extends Device {
         this.chimeHomebaseRingtoneType = chimeHomebaseRingtoneType;
     }
 
-    public int getNotificationRing() {
+    public boolean isNotificationRing() {
         return notificationRing;
     }
 
-    public void setNotificationRing(int notificationRing) {
+    public void setNotificationRing(boolean notificationRing) {
         this.notificationRing = notificationRing;
     }
 
-    public int getNotificationMotion() {
+    public boolean isNotificationMotion() {
         return notificationMotion;
     }
 
-    public void setNotificationMotion(int notificationMotion) {
+    public void setNotificationMotion(boolean notificationMotion) {
         this.notificationMotion = notificationMotion;
     }
 }

--- a/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/dto/objects/Doorbell.java
+++ b/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/dto/objects/Doorbell.java
@@ -36,9 +36,9 @@ public class Doorbell extends Device {
     @EufyChannel
     private int chimeHomebaseRingtoneType;
     @EufyChannel
-    private boolean notificationRing;
+    private BoolInt notificationRing;
     @EufyChannel
-    private boolean notificationMotion;
+    private BoolInt notificationMotion;
 
     public boolean isRinging() {
         return ringing;
@@ -104,19 +104,19 @@ public class Doorbell extends Device {
         this.chimeHomebaseRingtoneType = chimeHomebaseRingtoneType;
     }
 
-    public boolean isNotificationRing() {
-        return notificationRing;
+    public boolean getNotificationRing() {
+        return notificationRing.value;
     }
 
     public void setNotificationRing(boolean notificationRing) {
-        this.notificationRing = notificationRing;
+        this.notificationRing.value = notificationRing;
     }
 
-    public boolean isNotificationMotion() {
-        return notificationMotion;
+    public boolean getNotificationMotion() {
+        return notificationMotion.value;
     }
 
     public void setNotificationMotion(boolean notificationMotion) {
-        this.notificationMotion = notificationMotion;
+        this.notificationMotion.value = notificationMotion;
     }
 }

--- a/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/handlers/BaseEufyThingHander.java
+++ b/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/handlers/BaseEufyThingHander.java
@@ -30,6 +30,7 @@ import org.openhab.binding.eufy.internal.dto.MotionDetectedEvent;
 import org.openhab.binding.eufy.internal.dto.PersonDetectedEvent;
 import org.openhab.binding.eufy.internal.dto.PropertyChangedEvent;
 import org.openhab.binding.eufy.internal.dto.ResultMessage;
+import org.openhab.binding.eufy.internal.dto.RingsEvent;
 import org.openhab.binding.eufy.internal.dto.StateChangedEvent;
 import org.openhab.binding.eufy.internal.dto.objects.EufyObject;
 import org.openhab.core.library.types.DecimalType;
@@ -239,10 +240,12 @@ public abstract class BaseEufyThingHander extends BaseThingHandler {
     }
 
     public void eventReceived(Event event) {
+        // if (event.getEvent().contains("name")) {
         if (event instanceof PropertyChangedEvent) {
             PropertyChangedEvent propEvent = (PropertyChangedEvent) event;
             propertyChanged(propEvent.getName(), propEvent.getValue());
         } else if (event instanceof StateChangedEvent) {
+            // } else if (event.getEvent().contains("state")) {
             StateChangedEvent stateEvent = (StateChangedEvent) event;
             stateChanged(stateEvent);
         } else {
@@ -256,6 +259,8 @@ public abstract class BaseEufyThingHander extends BaseThingHandler {
             updateChannel(CHANNEL_PERSON_NAME, ((PersonDetectedEvent) stateEvent).getPerson());
         } else if (stateEvent instanceof MotionDetectedEvent) {
             updateChannel(CHANNEL_MOTION_DETECTED, ((MotionDetectedEvent) stateEvent).isState());
+        } else if (stateEvent instanceof RingsEvent) {
+            updateChannel(CHANNEL_RINGING, ((RingsEvent) stateEvent).isState());
         } else {
             logger.debug("Unhandled state change: {}", stateEvent.getEvent());
         }

--- a/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/handlers/BaseEufyThingHander.java
+++ b/bundles/org.openhab.binding.eufy/src/main/java/org/openhab/binding/eufy/internal/handlers/BaseEufyThingHander.java
@@ -240,12 +240,10 @@ public abstract class BaseEufyThingHander extends BaseThingHandler {
     }
 
     public void eventReceived(Event event) {
-        // if (event.getEvent().contains("name")) {
         if (event instanceof PropertyChangedEvent) {
             PropertyChangedEvent propEvent = (PropertyChangedEvent) event;
             propertyChanged(propEvent.getName(), propEvent.getValue());
         } else if (event instanceof StateChangedEvent) {
-            // } else if (event.getEvent().contains("state")) {
             StateChangedEvent stateEvent = (StateChangedEvent) event;
             stateChanged(stateEvent);
         } else {

--- a/bundles/org.openhab.binding.eufy/src/main/resources/OH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.eufy/src/main/resources/OH-INF/thing/channels.xml
@@ -168,13 +168,13 @@
 	</channel-type>
 
 	<channel-type id="notificationMotion" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Boolean</item-type>
 		<label>Notification Motion</label>
 		<description>Notification Motion</description>
 	</channel-type>
 
 	<channel-type id="notificationRing" advanced="true">
-		<item-type>Number</item-type>
+		<item-type>Boolean</item-type>
 		<label>Notification Ring</label>
 		<description>Notification Ring</description>
 	</channel-type>

--- a/bundles/org.openhab.binding.eufy/src/test/java/org/openhab/binding/eufy/internal/JsonParserTest.java
+++ b/bundles/org.openhab.binding.eufy/src/test/java/org/openhab/binding/eufy/internal/JsonParserTest.java
@@ -25,6 +25,7 @@ import org.openhab.binding.eufy.internal.dto.Message;
 import org.openhab.binding.eufy.internal.dto.MotionDetectedEvent;
 import org.openhab.binding.eufy.internal.dto.PersonDetectedEvent;
 import org.openhab.binding.eufy.internal.dto.PropertyChangedEvent;
+import org.openhab.binding.eufy.internal.dto.StateChangedEvent;
 import org.openhab.binding.eufy.internal.dto.StatusMessage;
 import org.openhab.binding.eufy.internal.dto.VersionMessage;
 import org.openhab.binding.eufy.internal.dto.objects.Device;
@@ -84,6 +85,17 @@ public class JsonParserTest {
         assertTrue(event.getEvent() instanceof MotionDetectedEvent);
         MotionDetectedEvent motion = (MotionDetectedEvent) event.getEvent();
         assertTrue(motion.isState());
+    }
+
+    @Test
+    public void testParseRingingEvent() throws Exception {
+        Message message = MessageHelper
+                .parse(Files.readString(Paths.get("src/test/resources/state_ringing_changed.json")));
+        assertTrue(message instanceof EventMessage);
+        EventMessage event = (EventMessage) message;
+        assertTrue(event.getEvent() instanceof StateChangedEvent);
+        StateChangedEvent ringingEvent = (StateChangedEvent) event.getEvent();
+        assertTrue(ringingEvent.isState());
     }
 
     @Test

--- a/bundles/org.openhab.binding.eufy/src/test/resources/get_properties_response.json
+++ b/bundles/org.openhab.binding.eufy/src/test/resources/get_properties_response.json
@@ -3,7 +3,7 @@
 	"success": true,
 	"messageId": "3",
 	"result": {
-		"serialNumber": "T8140P8121432028",
+		"serialNumber": "fake serial",
 		"properties": {
 			"name": {
 				"value": "Voordeur",
@@ -58,7 +58,7 @@
 				"timestamp": 1640335395000
 			},
 			"pictureUrl": {
-				"value": "https://zhixin-security-eu.s3.eu-central-1.amazonaws.com/thumb/2021/12/23/station/T8010P2321381032/lD0bjebWOQZkpTGa./camera00_20211224005444.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJYLV2KOLW6PU4FSA%2F20220101%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20220101T131208Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=bd8f0e7edc13597188db5a6d3248c2391de7db9b19896a31e83e3bda3a4a5105",
+				"value": "fake url",
 				"timestamp": 1640303683000
 			},
 			"recordingClipLength": {

--- a/bundles/org.openhab.binding.eufy/src/test/resources/motion_detected_event.json
+++ b/bundles/org.openhab.binding.eufy/src/test/resources/motion_detected_event.json
@@ -3,7 +3,7 @@
         "event":{
             "source": "device",
     	    "event": "motion detected",
-    	    "serialNumber": "T8140P8121432028",
+    	    "serialNumber": "fake serial",
     	    "state": true
     }
 }

--- a/bundles/org.openhab.binding.eufy/src/test/resources/person_detected_event.json
+++ b/bundles/org.openhab.binding.eufy/src/test/resources/person_detected_event.json
@@ -3,7 +3,7 @@
 	"event": {
 		"source": "device",
 		"event": "person detected",
-		"serialNumber": "T8140P8121432028",
+		"serialNumber": "fake serial",
 		"state": true,
 		"person": "Unknown"
 	}

--- a/bundles/org.openhab.binding.eufy/src/test/resources/property_ringing_changed.json
+++ b/bundles/org.openhab.binding.eufy/src/test/resources/property_ringing_changed.json
@@ -3,7 +3,7 @@
 	"event": {
 		"source": "device",
 		"event": "property changed",
-		"serialNumber": "T8220P60213118F1",
+		"serialNumber": "fake serial",
 		"name": "ringing",
 		"value": true,
 		"timestamp": 1640624653380

--- a/bundles/org.openhab.binding.eufy/src/test/resources/state_ringing_changed.json
+++ b/bundles/org.openhab.binding.eufy/src/test/resources/state_ringing_changed.json
@@ -3,7 +3,7 @@
 	"event": {
 		"source": "device",
 		"event": "rings",
-		"serialNumber": "T8140P8121432028",
+		"serialNumber": "fake serial",
 		"state": true
 	}
 }

--- a/bundles/org.openhab.binding.eufy/src/test/resources/state_ringing_changed.json
+++ b/bundles/org.openhab.binding.eufy/src/test/resources/state_ringing_changed.json
@@ -1,0 +1,9 @@
+{
+	"type": "event",
+	"event": {
+		"source": "device",
+		"event": "rings",
+		"serialNumber": "T8140P8121432028",
+		"state": true
+	}
+}


### PR DESCRIPTION
When using the latest version of the eufy-security-ws Docker container, the OpenHAB addon fails because it expects `NotificationRing` and `NotificationMotion` to be booleans now.